### PR TITLE
Circular Scroll: Fix scale of speed slider

### DIFF
--- a/kcmtouchpad.cpp
+++ b/kcmtouchpad.cpp
@@ -48,6 +48,9 @@
 K_PLUGIN_FACTORY(TouchpadConfigFactory, registerPlugin<TouchpadConfig>("touchpad");)
 K_EXPORT_PLUGIN(TouchpadConfigFactory("kcmtouchpad"))
 
+// The slider is in degrees, but config and touchpad is in radians
+static const double ScrollCircularScale = 180.0/M_PI;
+
 TouchpadConfig::TouchpadConfig(QWidget *parent, const QVariantList &)
         : KCModule(TouchpadConfigFactory::componentData(), parent),
 	setup_failed(false)
@@ -229,7 +232,7 @@ void TouchpadConfig::load()
         ui->ScrollCircularEnableCB->setCheckState(config.readEntry("CircularScrolling", (int)*(char*)Touchpad::get_parameter("CircularScrolling")) ? Qt::Checked : Qt::Unchecked);
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_DIST)) {
-        ui->ScrollCircularSpeedS->setValue(config.readEntry("CircScrollDelta", *(double*)Touchpad::get_parameter("CircScrollDelta")));
+        ui->ScrollCircularSpeedS->setValue(ScrollCircularScale*config.readEntry("CircScrollDelta", *(double*)Touchpad::get_parameter("CircScrollDelta")));
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_TRIGGER)) {
         ui->ScrollCircularCornersCBB->setCurrentIndex(config.readEntry("CircScrollTrigger", (int)*(char*)Touchpad::get_parameter("CircScrollTrigger")));
@@ -309,7 +312,7 @@ void TouchpadConfig::save()
         config.writeEntry("CircularScrolling", (int)ui->ScrollCircularEnableCB->isChecked());
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_DIST)) {
-        config.writeEntry("CircScrollDelta", (double)ui->ScrollCircularSpeedS->value());
+        config.writeEntry("CircScrollDelta", (double)ui->ScrollCircularSpeedS->value() / ScrollCircularScale);
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_TRIGGER)) {
         config.writeEntry("CircScrollTrigger", ui->ScrollCircularCornersCBB->currentIndex());
@@ -453,7 +456,7 @@ bool TouchpadConfig::apply()
         Touchpad::set_parameter("CircularScrolling", ui->ScrollCircularEnableCB->isChecked());
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_DIST)) {
-        Touchpad::set_parameter("CircScrollDelta", ui->ScrollCircularSpeedS->value());
+        Touchpad::set_parameter("CircScrollDelta", (double)ui->ScrollCircularSpeedS->value() / ScrollCircularScale);
     }
     if (this->propertiesList.contains(SYNAPTICS_PROP_CIRCULAR_SCROLLING_TRIGGER)) {
         Touchpad::set_parameter("CircScrollTrigger", ui->ScrollCircularCornersCBB->currentIndex());

--- a/kcmtouchpadwidget.ui
+++ b/kcmtouchpadwidget.ui
@@ -796,19 +796,19 @@
                <string>Move angle (radians) of finger to generate a scroll event.</string>
               </property>
               <property name="minimum">
-               <number>30</number>
+               <number>1</number>
               </property>
               <property name="maximum">
-               <number>300</number>
-              </property>
-              <property name="singleStep">
-               <number>30</number>
-              </property>
-              <property name="pageStep">
                <number>60</number>
               </property>
+              <property name="singleStep">
+               <number>1</number>
+              </property>
+              <property name="pageStep">
+               <number>10</number>
+              </property>
               <property name="value">
-               <number>300</number>
+               <number>10</number>
               </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -823,7 +823,7 @@
                <enum>QSlider::TicksBelow</enum>
               </property>
               <property name="tickInterval">
-               <number>30</number>
+               <number>10</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
The range of values in circular scroll speed make circular scroll so slow it appears not to work (the delta is measured in radians but the range of the slider was 30-300). This is my fix for this, making the slider measure in degrees, and converting to radians before saving to config or setting the touchpad parameter.
